### PR TITLE
Alt text for Tinymce

### DIFF
--- a/src/Configuration/ImageshopSettings.cs
+++ b/src/Configuration/ImageshopSettings.cs
@@ -135,12 +135,12 @@ namespace Geta.EPi.Imageshop.Configuration
             }
         }
 
-        [ConfigurationProperty("webServiceUrl", DefaultValue = "http://imageshop.no/ws/v4.asmx", IsRequired = false)]
+        [ConfigurationProperty("webServiceUrl", DefaultValue = "https://webservices.imageshop.no/v4.asmx", IsRequired = false)]
         public string WebServiceUrl
         {
             get
             {
-                return this["webServiceUrl"] as string ?? "http://imageshop.no/ws/v4.asmx";
+                return this["webServiceUrl"] as string ?? "https://webservices.imageshop.no/v4.asmx";
             }
             set
             {

--- a/src/Configuration/ImageshopSettings.cs
+++ b/src/Configuration/ImageshopSettings.cs
@@ -18,12 +18,12 @@ namespace Geta.EPi.Imageshop.Configuration
             }
         }
 
-        [ConfigurationProperty("baseUrl", DefaultValue = "https://client.imageshop.no/InsertImage.aspx", IsRequired = false)]
+        [ConfigurationProperty("baseUrl", DefaultValue = "https://client.imageshop.no/InsertImage2.aspx", IsRequired = false)]
         public string BaseUrl
         {
             get
             {
-                return this["baseUrl"] as string ?? "https://client.imageshop.no/InsertImage.aspx?IFRAMEINSERT=true";
+                return this["baseUrl"] as string ?? "https://client.imageshop.no/InsertImage2.aspx?IFRAMEINSERT=true";
             }
             set
             {

--- a/src/TinyMce/ClientResources/InsertImage.aspx
+++ b/src/TinyMce/ClientResources/InsertImage.aspx
@@ -91,42 +91,72 @@
 
         });
 
-        function insert(file, title, width, height) {
+        function insert(file, title, width, height, alignment = null, descriptionstring = null) {
+
             var ed = tinyMCEPopup.editor, dom = ed.dom;
 
             var imgobj;
+            var descriptionobject = null;
 
-            if (height && height != 0) {
-
+            if (descriptionstring != null) {
+                descriptionobject = JSON.parse(descriptionstring);
                 imgobj = {
                     src: file,
-                    alt: title,
-                    title: title,
-                    border: 0,
-                    width: width,
-                    height: height
-                };
+                    alt: descriptionobject.Description ? descriptionobject.Description : descriptionobject.Name,
+                    border: null,
+                    'data-credits': descriptionobject.Credits,
+                    'data-authorName': descriptionobject.AuthorName,
+                    'data-tags': descriptionobject.Tags,
+                    'data-name': descriptionobject.Name,
+                    'data-description': descriptionobject.Description
+
+                }
+                if (height != 0) {
+                    imgobj.height = height;
+                }
+                if (width != 0) {
+                    imgobj.width = width;
+                }
             }
-            else if (width && width != 0) {
-                imgobj = {
-                    src: file,
-                    alt: title,
-                    title: title,
-                    border: 0,
-                    width: width
-                };
-            } else {
-                imgobj = {
-                    src: file,
-                    alt: title,
-                    title: title,
-                    border: 0
-                };
+            else {
+
+                if (height != 0) {
+
+                    imgobj = {
+                        src: file,
+                        alt: title,
+                        title: title,
+                        border: 0,
+                        width: width,
+                        height: height
+                    };
+                }
+                else if (width != 0) {
+                    imgobj = {
+                        src: file,
+                        alt: title,
+                        title: title,
+                        border: 0,
+                        width: width
+                    };
+                } else {
+                    imgobj = {
+                        src: file,
+                        alt: title,
+                        title: title,
+                        border: 0
+                    };
+                }
+            }
+
+            if (alignment != null) {
+                imgobj["style"] = "float: " + alignment;
             }
 
             tinyMCEPopup.execCommand('mceInsertContent', false, dom.createHTML('img', imgobj));
 
             tinyMCEPopup.close();
+
         }
 
     </script>

--- a/src/TinyMce/ClientResources/InsertImage.aspx
+++ b/src/TinyMce/ClientResources/InsertImage.aspx
@@ -74,7 +74,7 @@
                 params = loc.split('?')[1],
                 iframe = document.getElementById("MyFrame");
 
-            iframe.src = clienthost + "/InsertImage.aspx?" + params + '&IFRAMEINSERT=true&IMAGESHOPTOKEN=' + token + '&SHOWSIZEDIALOGUE=' + showSizeDialog + '&SHOWCROPDIALOGUE=' + showCropDialog + '&FREECROP=' + freeCrop + '&IMAGESHOPINTERFACENAME=' + interfaceName + '&IMAGESHOPDOCUMENTPREFIX=' + documentPrefix + '&IMAGESHOPSIZES=' + sizePresets;
+            iframe.src = clienthost + "/InsertImage2.aspx?" + params + '&IFRAMEINSERT=true&IMAGESHOPTOKEN=' + token + '&SHOWSIZEDIALOGUE=' + showSizeDialog + '&SHOWCROPDIALOGUE=' + showCropDialog + '&FREECROP=' + freeCrop + '&IMAGESHOPINTERFACENAME=' + interfaceName + '&IMAGESHOPDOCUMENTPREFIX=' + documentPrefix + '&IMAGESHOPSIZES=' + sizePresets;
 
             $(window).resize(function () {
                 setSize();

--- a/src/TinyMce/ClientResources/editor_plugin.js
+++ b/src/TinyMce/ClientResources/editor_plugin.js
@@ -4,7 +4,7 @@ tinymce.PluginManager.add("getaepiimageshop", function (ed, url) {
     var imageNode;
     // Register commands
     ed.addCommand('mcegetaepiimageshop', function () {
-        var dialogUrl = url + "/InsertImage.aspx?TINYMCE=true";
+        var dialogUrl = url + "/InsertImage.aspx?TINYMCE=true&TINYMCEEXTENDED=true";
 
         if (ed.selection !== null && ed.selection.getNode() !== null && ed.selection.getNode().src !== null)
             dialogUrl += "&IMAGE=" + encodeURIComponent(ed.selection.getNode().src);


### PR DESCRIPTION
Use new option TINYMCEEXTENDED=true to use description with fallback to name as alt text and add data attributes for credits, authorName, tags, name, description. Title will not be set. This is a change from before, when credits was used for alt text and title, and no data attributes was set.